### PR TITLE
Added author + pack version

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -63,6 +63,22 @@ var initCmd = &cobra.Command{
 			}
 		}
 
+		// Pack author
+		author, err := cmd.Flags().GetString("author")
+		if err != nil || len(name) == 0 {
+			fmt.Print("Author: ")
+			readAuthor, err := bufio.NewReader(os.Stdin).ReadString('\n')
+			if err != nil {
+				fmt.Printf("Error reading input: %s\n", err)
+				os.Exit(1)
+			}
+			// Trims both CR and LF
+			readAuthor = strings.TrimSpace(strings.TrimRight(readAuthor, "\r\n"))
+			if len(readAuthor) > 0 {
+				author = readAuthor
+			}
+		}
+
 		mcVersions, err := getValidMCVersions()
 		if err != nil {
 			fmt.Printf("Failed to get latest minecraft versions: %s\n", err)
@@ -186,6 +202,8 @@ var initCmd = &cobra.Command{
 		// Create the pack
 		pack := core.Pack{
 			Name: name,
+			Author: author,
+			Version: "1.0.0",
 			Index: struct {
 				File       string `toml:"file"`
 				HashFormat string `toml:"hash-format"`

--- a/core/pack.go
+++ b/core/pack.go
@@ -13,19 +13,19 @@ import (
 
 // Pack stores the modpack metadata, usually in pack.toml
 type Pack struct {
-	Name  string `toml:"name"`
-	Author string `toml:"author"`
+	Name    string `toml:"name"`
+	Author  string `toml:"author"`
 	Version string `toml:"version"`
-	ProjectID int `toml:"project_id"`
-	Index struct {
+	Index   struct {
 		// Path is stored in forward slash format relative to pack.toml
 		File       string `toml:"file"`
 		HashFormat string `toml:"hash-format"`
 		Hash       string `toml:"hash"`
 	} `toml:"index"`
-	Versions map[string]string         `toml:"versions"`
-	Client   map[string]toml.Primitive `toml:"client"`
-	Server   map[string]toml.Primitive `toml:"server"`
+	Versions map[string]string                 `toml:"versions"`
+	Client   map[string]toml.Primitive         `toml:"client"`
+	Server   map[string]toml.Primitive         `toml:"server"`
+	Export   map[string]map[string]interface{} `toml:"export"`
 }
 
 // LoadPack loads the modpack metadata to a Pack struct
@@ -109,9 +109,9 @@ func (pack Pack) GetMCVersion() (string, error) {
 	return mcVersion, nil
 }
 
-func (pack Pack) GetPackName() (string) {
+func (pack Pack) GetPackName() string {
 	if pack.Name == "" {
-		return "pack"
+		return "export"
 	} else if pack.Version == "" {
 		return pack.Name
 	} else {

--- a/core/pack.go
+++ b/core/pack.go
@@ -14,6 +14,9 @@ import (
 // Pack stores the modpack metadata, usually in pack.toml
 type Pack struct {
 	Name  string `toml:"name"`
+	Author string `toml:"author"`
+	Version string `toml:"version"`
+	ProjectID int `toml:"project_id"`
 	Index struct {
 		// Path is stored in forward slash format relative to pack.toml
 		File       string `toml:"file"`
@@ -104,4 +107,14 @@ func (pack Pack) GetMCVersion() (string, error) {
 		return "", errors.New("no minecraft version specified in modpack")
 	}
 	return mcVersion, nil
+}
+
+func (pack Pack) GetPackName() (string) {
+	if pack.Name == "" {
+		return "pack"
+	} else if pack.Version == "" {
+		return pack.Name
+	} else {
+		return pack.Name + "-" + pack.Version
+	}
 }

--- a/curseforge/curseforge.go
+++ b/curseforge/curseforge.go
@@ -345,3 +345,19 @@ func (u cfUpdater) DoUpdate(mods []*core.Mod, cachedState []interface{}) error {
 
 	return nil
 }
+
+type cfExportData struct {
+	ProjectID int `mapstructure:"project-id"`
+}
+
+func (e cfExportData) ToMap() (map[string]interface{}, error) {
+	newMap := make(map[string]interface{})
+	err := mapstructure.Decode(e, &newMap)
+	return newMap, err
+}
+
+func parseExportData(from map[string]interface{}) (cfExportData, error) {
+	var exportData cfExportData
+	err := mapstructure.Decode(from, &exportData)
+	return exportData, err
+}

--- a/curseforge/export.go
+++ b/curseforge/export.go
@@ -78,7 +78,9 @@ var exportCmd = &cobra.Command{
 		}
 		mods = mods[:i]
 
-		expFile, err := os.Create("export.zip")
+		var fileName = pack.GetPackName() + ".zip"
+
+		expFile, err := os.Create(fileName)
 		if err != nil {
 			fmt.Printf("Failed to create zip: %s\n", err.Error())
 			os.Exit(1)
@@ -188,7 +190,7 @@ var exportCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Println("Modpack exported to export.zip!")
+		fmt.Println("Modpack exported to " + fileName)
 	},
 }
 

--- a/curseforge/packinterop/translation.go
+++ b/curseforge/packinterop/translation.go
@@ -69,7 +69,7 @@ type AddonFileReference struct {
 	OptionalDisabled bool
 }
 
-func WriteManifestFromPack(pack core.Pack, fileRefs []AddonFileReference, out io.Writer) error {
+func WriteManifestFromPack(pack core.Pack, fileRefs []AddonFileReference, projectID int, out io.Writer) error {
 	files := make([]struct {
 		ProjectID int  `json:"projectID"`
 		FileID    int  `json:"fileID"`
@@ -105,7 +105,7 @@ func WriteManifestFromPack(pack core.Pack, fileRefs []AddonFileReference, out io
 		NameInternal:    pack.Name,
 		Version:         pack.Version,
 		Author:          pack.Author,
-		ProjectID:       pack.ProjectID,
+		ProjectID:       projectID,
 		Files:           files,
 		Overrides:       "overrides",
 	}

--- a/curseforge/packinterop/translation.go
+++ b/curseforge/packinterop/translation.go
@@ -103,9 +103,9 @@ func WriteManifestFromPack(pack core.Pack, fileRefs []AddonFileReference, out io
 		ManifestType:    "minecraftModpack",
 		ManifestVersion: 1,
 		NameInternal:    pack.Name,
-		Version:         "", // TODO: store or take this?
-		Author:          "", // TODO: store or take this?
-		ProjectID:       0,  // TODO: store or take this?
+		Version:         pack.Version,
+		Author:          pack.Author,
+		ProjectID:       pack.ProjectID,
 		Files:           files,
 		Overrides:       "overrides",
 	}


### PR DESCRIPTION
I noticed that packwiz cant export curseforge modpacks with the author/version fields populated. So I added these as additional pack parameters stored in the pack.toml

The author is also prompted to type in his name in the init process. Version defaults to 1.0.0 for newly inited packs.

The exported pack name is also now by default [Packname]-[Version].zip instead of export.zip.