### PR TITLE
Print file name in file export error messages

### DIFF
--- a/curseforge/export.go
+++ b/curseforge/export.go
@@ -114,13 +114,13 @@ var exportCmd = &cobra.Command{
 				}
 				modFile, err := exp.Create(filepath.ToSlash(filepath.Join("overrides", path)))
 				if err != nil {
-					fmt.Printf("Error creating mod file: %s\n", err.Error())
+					fmt.Printf("Error creating mod file %s: %s\n", path, err.Error())
 					// TODO: exit(1)?
 					continue
 				}
 				err = mod.DownloadFile(modFile)
 				if err != nil {
-					fmt.Printf("Error downloading mod file: %s\n", err.Error())
+					fmt.Printf("Error downloading mod file %s: %s\n", path, err.Error())
 					// TODO: exit(1)?
 					continue
 				}
@@ -237,7 +237,7 @@ func loadMods(index core.Index) []core.Mod {
 	for _, v := range modPaths {
 		modData, err := core.LoadMod(v)
 		if err != nil {
-			fmt.Printf("Error reading mod file: %s\n", err.Error())
+			fmt.Printf("Error reading mod file %s: %s\n", v, err.Error())
 			// TODO: exit(1)?
 			continue
 		}


### PR DESCRIPTION
Was having trouble finding offending files with the current export error messages, so I slightly tweaked the print statements to tell you which file is failing.

**Before**:
![image](https://user-images.githubusercontent.com/17728338/96385721-4eff9180-115b-11eb-87df-461fa40ea6d0.png)

**After**:
![image](https://user-images.githubusercontent.com/17728338/96385731-5757cc80-115b-11eb-87ca-d176b522abef.png)
