### PR TITLE
Add more detailed errors to clarify hash issues

### DIFF
--- a/core/mod.go
+++ b/core/mod.go
@@ -152,9 +152,9 @@ func (m Mod) DownloadFile(dest io.Writer) error {
 	// Check if the hash of the downloaded file matches the expected hash.
 	// Also check if the uppercase version of the expected hash matches.
 	if(strings.ToUpper(calculatedHash) != m.Download.Hash) {
-		return errors.New(fmt.Sprintf("Hash of saved file %s only matches when uppercased. Consider changing this to prevent future issues.", m.GetFilePath()))
+		return errors.New(fmt.Sprintf("Hash of saved file %s only matches when uppercased. Consider changing this to prevent future issues.\n", m.GetFilePath()))
 	} else if calculatedHash != m.Download.Hash {
-		return errors.New(fmt.Sprintf("hash of saved file is invalid!\n .toml hash: %s\n download hash: %s", calculatedHash, m.Download.Hash))
+		return errors.New(fmt.Sprintf("hash of saved file is invalid!\n .toml hash: %s\n download hash: %s\n", calculatedHash, m.Download.Hash))
 	}
 
 	return nil

--- a/core/mod.go
+++ b/core/mod.go
@@ -148,8 +148,14 @@ func (m Mod) DownloadFile(dest io.Writer) error {
 	}
 
 	calculatedHash := hex.EncodeToString(h.Sum(nil))
-	if calculatedHash != m.Download.Hash && strings.ToUpper(calculatedHash) != m.Download.Hash {
+
+	// Check if the hash of the downloaded file matches the expected hash.
+	// Also check if the uppercase version of the expected hash matches.
+	if(strings.ToUpper(calculatedHash) != m.Download.Hash) {
+		return errors.New(fmt.Sprintf("Hash of saved file %s only matches when uppercased. Consider changing this to prevent future issues.", m.GetFilePath()))
+	} else if calculatedHash != m.Download.Hash {
 		return errors.New(fmt.Sprintf("hash of saved file is invalid!\n .toml hash: %s\n download hash: %s", calculatedHash, m.Download.Hash))
 	}
+
 	return nil
 }

--- a/core/mod.go
+++ b/core/mod.go
@@ -150,7 +150,7 @@ func (m Mod) DownloadFile(dest io.Writer) error {
 
 	// Check if the hash of the downloaded file matches the expected hash.
 	if calculatedHash != m.Download.Hash {
-		return errors.New(fmt.Sprintf("Hash of downloaded file does not match with expected hash!\n download hash: %s\n expected hash: %s\n", calculatedHash, m.Download.Hash))
+		return fmt.Errorf("Hash of downloaded file does not match with expected hash!\n download hash: %s\n expected hash: %s\n", calculatedHash, m.Download.Hash)
 	}
 
 	return nil

--- a/core/mod.go
+++ b/core/mod.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"fmt"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -146,8 +148,8 @@ func (m Mod) DownloadFile(dest io.Writer) error {
 	}
 
 	calculatedHash := hex.EncodeToString(h.Sum(nil))
-	if calculatedHash != m.Download.Hash {
-		return errors.New("hash of saved file is invalid")
+	if calculatedHash != m.Download.Hash && strings.ToUpper(calculatedHash) != m.Download.Hash {
+		return errors.New(fmt.Sprintf("hash of saved file is invalid!\n .toml hash: %s\n download hash: %s", calculatedHash, m.Download.Hash))
 	}
 	return nil
 }

--- a/core/mod.go
+++ b/core/mod.go
@@ -150,7 +150,7 @@ func (m Mod) DownloadFile(dest io.Writer) error {
 
 	// Check if the hash of the downloaded file matches the expected hash.
 	if calculatedHash != m.Download.Hash {
-		return errors.New(fmt.Sprintf("Hash of downloaded file does no match with expected hash!\n download hash: %s\n expected hash: %s\n", calculatedHash, m.Download.Hash))
+		return errors.New(fmt.Sprintf("Hash of downloaded file does not match with expected hash!\n download hash: %s\n expected hash: %s\n", calculatedHash, m.Download.Hash))
 	}
 
 	return nil

--- a/core/mod.go
+++ b/core/mod.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"fmt"
-	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -150,11 +149,8 @@ func (m Mod) DownloadFile(dest io.Writer) error {
 	calculatedHash := hex.EncodeToString(h.Sum(nil))
 
 	// Check if the hash of the downloaded file matches the expected hash.
-	// Also check if the uppercase version of the expected hash matches.
-	if(strings.ToUpper(calculatedHash) != m.Download.Hash) {
-		return errors.New(fmt.Sprintf("Hash of saved file %s only matches when uppercased. Consider changing this to prevent future issues.\n", m.GetFilePath()))
-	} else if calculatedHash != m.Download.Hash {
-		return errors.New(fmt.Sprintf("hash of saved file is invalid!\n .toml hash: %s\n download hash: %s\n", calculatedHash, m.Download.Hash))
+	if calculatedHash != m.Download.Hash {
+		return errors.New(fmt.Sprintf("Hash of downloaded file does no match with expected hash!\n download hash: %s\n expected hash: %s\n", calculatedHash, m.Download.Hash))
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds tweaked error messages for when hashes don't match up. 

~~I also noticed some hashes come back (might be from CF or Discord?) as uppercase when hash-providing tools claim they are lowercase. I added a special warning for it.~~ Might be Powershell doing the uppercasing, just going to remove it in favor of keeping all errors the same here.

![image](https://user-images.githubusercontent.com/17728338/96518561-cb17d900-1230-11eb-91c2-8ca49caaf460.png)


